### PR TITLE
Allow plugin to connect to non localhost server

### DIFF
--- a/webscripthook-plugin/MainScript.cs
+++ b/webscripthook-plugin/MainScript.cs
@@ -66,12 +66,13 @@ namespace WebScriptHook
                 // fallback
                 settings = ScriptSettings.Load(pathFallback);
             }
+            string host = settings.GetValue("Core", "HOST", "localhost");
             string port = settings.GetValue("Core", "PORT", "25555");
             int interval = settings.GetValue("Core", "INTERVAL", 10);
             Logger.Enable = settings.GetValue("Core", "LOGGING", false);
 
             //url = "http://localhost:" + port + "/push";
-            url = "ws://localhost:" + port + "/pushws";
+            url = "ws://" + host + ":" + port + "/pushws";
             sleepTime = interval;
         }
 

--- a/webscripthook-plugin/WebScriptHook.ini
+++ b/webscripthook-plugin/WebScriptHook.ini
@@ -1,4 +1,5 @@
 [Core]
+HOST=localhost
 PORT=25555
 INTERVAL=10
 LOGGING=false

--- a/webscripthook-server/WebScriptHook.ini
+++ b/webscripthook-server/WebScriptHook.ini
@@ -1,4 +1,5 @@
 [Core]
+HOST=localhost
 PORT=25555
 INTERVAL=10
 LOGGING=false

--- a/webscripthook-server/configloader.go
+++ b/webscripthook-server/configloader.go
@@ -15,6 +15,7 @@ func getPort() string {
 	fmt.Println(cfgStr)
 	cfg := struct {
 		Core struct {
+			HOST     string
 			PORT     string
 			INTERVAL int
 			LOGGING  bool


### PR DESCRIPTION
And since the server is written in Go, this should allow server deployment on non Windows systems.
The plugin has to run on Windows because the game is only for WIndows....

Tested with server running on a raspberry pi :laughing: 